### PR TITLE
Resolve an issue where Prisma generation would fail on alternative package managers

### DIFF
--- a/playground/.npmrc
+++ b/playground/.npmrc
@@ -1,0 +1,1 @@
+hoist-pattern[]=*prisma*

--- a/playground/.npmrc
+++ b/playground/.npmrc
@@ -1,1 +1,0 @@
-hoist-pattern[]=*prisma*

--- a/playground/components/PostList.server.vue
+++ b/playground/components/PostList.server.vue
@@ -4,6 +4,8 @@ const post = await prisma.post.findFirst();
 </script>
 
 <template>
-  <div>Posts</div>
-  <p>{{ post?.title ?? "There is no post." }}</p>
+  <div>
+    <div>Posts</div>
+    <p>{{ post?.title ?? "There is no post." }}</p>
+  </div>
 </template>

--- a/src/package-utils/setup-helpers.ts
+++ b/src/package-utils/setup-helpers.ts
@@ -29,7 +29,7 @@ export async function isPrismaCLIInstalled(
   directory: string,
 ): Promise<boolean> {
   try {
-    await execa("prisma", ["version"], { cwd: directory });
+    await execa("npx", ["prisma", "version"], { cwd: directory });
     logSuccess(PREDEFINED_LOG_MESSAGES.isPrismaCLIinstalled.yes);
     return true;
   } catch (error) {
@@ -72,7 +72,7 @@ export async function initPrisma({
   provider = "sqlite",
   datasourceUrl,
 }: PrismaInitOptions) {
-  const command = ["prisma", "init", "--datasource-provider"];
+  const command = ["npx", "prisma", "init", "--datasource-provider"];
 
   command.push(provider);
 

--- a/src/package-utils/setup-helpers.ts
+++ b/src/package-utils/setup-helpers.ts
@@ -1,5 +1,8 @@
 import { execa } from "execa";
-import { installingPrismaCLIWithPM } from "./detect-pm";
+import {
+  installingPrismaClientWithPM,
+  installingPrismaCLIWithPM,
+} from "./detect-pm";
 import {
   log,
   logError,
@@ -37,9 +40,10 @@ export async function isPrismaCLIInstalled(
 }
 
 export async function installPrismaCLI(directory: string) {
-
   try {
-    await execa("npm", ["install", "prisma", "--save-dev"], {
+    const installCmd = installingPrismaCLIWithPM();
+
+    await execa(installCmd.pm, installCmd.command, {
       cwd: directory,
     });
     logSuccess(PREDEFINED_LOG_MESSAGES.installPrismaCLI.yes);
@@ -173,10 +177,9 @@ export async function generateClient(
 ) {
   log(PREDEFINED_LOG_MESSAGES.generatePrismaClient.action);
 
-
   if (installPrismaClient) {
     try {
-      const installCmd = installingPrismaCLIWithPM();
+      const installCmd = installingPrismaClientWithPM();
 
       await execa(installCmd.pm, installCmd.command, {
         cwd: directory,

--- a/src/package-utils/setup-helpers.ts
+++ b/src/package-utils/setup-helpers.ts
@@ -1,4 +1,5 @@
 import { execa } from "execa";
+import { installingPrismaCLIWithPM } from "./detect-pm";
 import {
   log,
   logError,
@@ -175,7 +176,9 @@ export async function generateClient(
 
   if (installPrismaClient) {
     try {
-      await execa("npm", ["install", "@prisma/client", "--save-dev"], {
+      const installCmd = installingPrismaCLIWithPM();
+
+      await execa(installCmd.pm, installCmd.command, {
         cwd: directory,
       });
     } catch (error) {


### PR DESCRIPTION
Howdy,

This PR resolves issue https://github.com/prisma/nuxt-prisma/issues/15 by using the existing `detect-pm.ts` file to pick the relevant package manager in the setup step.