### PR TITLE
Fix auto-import for runtime/server/utils

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -3,7 +3,7 @@ import {
   addPlugin,
   createResolver,
   addImportsDir,
-  addServerScanDir,
+  addServerImportsDir,
 } from "@nuxt/kit";
 import { fileURLToPath } from "url";
 import defu from "defu";
@@ -82,9 +82,7 @@ export default defineNuxtModule<PrismaExtendedModule>({
       addImportsDir(resolver(runtimeDir, "composables"));
 
       // Auto-import from runtime/server/utils
-      addServerScanDir(
-        createResolver(import.meta.url).resolve("./runtime/server"),
-      );
+      addServerImportsDir(resolver(runtimeDir, "utils"));
 
       nuxt.options.vite.optimizeDeps ||= {};
       nuxt.options.vite.optimizeDeps = {


### PR DESCRIPTION
Should use addServerImportsDir instead of addServerScanDir.

Try fix issue #12 