### PR TITLE
chore: remove unused skipInstallations option

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -32,7 +32,6 @@ interface ModuleOptions extends Prisma.PrismaClientOptions {
   installCLI: boolean;
   generateClient: boolean;
   installStudio: boolean;
-  skipInstallations: boolean;
   autoSetupPrisma: boolean;
 }
 
@@ -59,7 +58,6 @@ export default defineNuxtModule<PrismaExtendedModule>({
     installCLI: true,
     generateClient: true,
     installStudio: true,
-    skipInstallations: false,
     autoSetupPrisma: false,
   },
 


### PR DESCRIPTION
The `skipInstallations` option is not used in any business logic and is undocumented. Removing it will prevent potential confusion for developers.