### PR TITLE
feat: add writeClientInLib option to module configuration

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -30,6 +30,7 @@ interface ModuleOptions extends Prisma.PrismaClientOptions {
   runMigration: boolean;
   installClient: boolean;
   installCLI: boolean;
+  writeClientInLib: boolean;
   generateClient: boolean;
   installStudio: boolean;
   skipInstallations: boolean;
@@ -57,6 +58,7 @@ export default defineNuxtModule<PrismaExtendedModule>({
     runMigration: true,
     installClient: true,
     installCLI: true,
+    writeClientInLib: true,
     generateClient: true,
     installStudio: true,
     skipInstallations: false,
@@ -226,7 +228,9 @@ export default defineNuxtModule<PrismaExtendedModule>({
       await prismaMigrateWorkflow();
     }
 
-    await writeClientInLib(resolveProject("lib", "prisma.ts"));
+    if (options.writeClientInLib) {
+      await writeClientInLib(resolveProject("lib", "prisma.ts"));
+    }
 
     if (options.generateClient) {
       await generateClient(PROJECT_PATH, options.installClient);


### PR DESCRIPTION
This PR introduces a new option `writeClientInLib` to the module configuration, allowing finer control over the module setup process.

Some projects already export a Prisma client elsewhere, so the additional file generated in the lib folder may be unwanted. This option allows users to skip this step when it's not needed, preventing redundancy.