### PR TITLE
fix: remove redundant npx

### DIFF
--- a/src/package-utils/setup-helpers.ts
+++ b/src/package-utils/setup-helpers.ts
@@ -72,7 +72,7 @@ export async function initPrisma({
   provider = "sqlite",
   datasourceUrl,
 }: PrismaInitOptions) {
-  const command = ["npx", "prisma", "init", "--datasource-provider"];
+  const command = ["prisma", "init", "--datasource-provider"];
 
   command.push(provider);
 


### PR DESCRIPTION
The command should be `npx prisma` instead of `npx npx prisma`