### PR TITLE
fix: replace spawn with execa to fix Windows compatibility

### DIFF
--- a/src/package-utils/setup-helpers.ts
+++ b/src/package-utils/setup-helpers.ts
@@ -211,13 +211,13 @@ export async function generateClient(
 
 export async function installStudio(directory: string) {
   try {
-    const { spawn } = require("child_process");
-
     log(PREDEFINED_LOG_MESSAGES.installStudio.action);
 
-    await spawn("npx", ["prisma", "studio", "--browser", "none"], {
-      cwd: directory,
+    const subprocess = execa("npx", ["prisma", "studio", "--browser", "none"], {
+      cwd: directory
     });
+    
+    subprocess.unref();
 
     logSuccess(PREDEFINED_LOG_MESSAGES.installStudio.success);
 


### PR DESCRIPTION
### Description

This PR replaces the usage of `spawn` with `execa` to resolve compatibility issues on Windows systems.

### Changes Made
- Replaced all occurrences of `spawn` with `execa` in the `installStudio` function.
- Ensured that Prisma Studio runs asynchronously without blocking the execution of the rest of the code.

### Issue
Should fix issues #35 and #13  