### PR TITLE
refactor: replace own installation functions with nypm ensureDependencyInstalled

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -13,11 +13,8 @@ import {
   checkIfMigrationsFolderExists,
   checkIfPrismaSchemaExists,
   formatSchema,
-  installPrismaClient,
   initPrisma,
-  installPrismaCLI,
   installStudio,
-  isPrismaCLIInstalled,
   runMigration,
   writeClientInLib,
   writeToSchema,
@@ -26,6 +23,7 @@ import {
 import { log, PREDEFINED_LOG_MESSAGES } from "./package-utils/log-helpers";
 import type { Prisma } from "@prisma/client";
 import { executeRequiredPrompts } from "./package-utils/prompts";
+import { ensureDependencyInstalled } from "nypm";
 
 // Module configuration interface
 interface ModuleOptions extends Prisma.PrismaClientOptions {
@@ -140,15 +138,22 @@ export default defineNuxtModule<PrismaExtendedModule>({
 
     // Ensure Prisma CLI is installed if required
     if (options.installCLI) {
-      const prismaInstalled = await isPrismaCLIInstalled(PROJECT_PATH);
-      if (!prismaInstalled) {
-        await installPrismaCLI(PROJECT_PATH);
-        await generatePrismaClient(
-          PROJECT_PATH,
-          PRISMA_SCHEMA_CMD,
-          options.log?.includes("error"),
-        );
+      log(PREDEFINED_LOG_MESSAGES.installPrismaCLI.action);
+
+      try {
+        await ensureDependencyInstalled("prisma", {
+          cwd: PROJECT_PATH,
+          dev: true
+        });
+        log(PREDEFINED_LOG_MESSAGES.installPrismaCLI.success);
+      } catch (error) {
+        log(PREDEFINED_LOG_MESSAGES.installPrismaCLI.error);
       }
+      await generatePrismaClient(
+        PROJECT_PATH,
+        PRISMA_SCHEMA_CMD,
+        options.log?.includes("error"),
+      );
     }
 
     // Check if Prisma schema exists
@@ -242,7 +247,12 @@ export default defineNuxtModule<PrismaExtendedModule>({
     await writeClientInLib(LAYER_PATH);
 
     if (options.generateClient) {
-      await installPrismaClient(PROJECT_PATH, options.installClient);
+      if (options.installClient) {
+        await ensureDependencyInstalled("@prisma/client", {
+          cwd: PROJECT_PATH,
+          dev: true
+        });
+      }
       await generatePrismaClient(
         PROJECT_PATH,
         PRISMA_SCHEMA_CMD,

--- a/src/module.ts
+++ b/src/module.ts
@@ -249,8 +249,7 @@ export default defineNuxtModule<PrismaExtendedModule>({
     if (options.generateClient) {
       if (options.installClient) {
         await ensureDependencyInstalled("@prisma/client", {
-          cwd: PROJECT_PATH,
-          dev: true
+          cwd: PROJECT_PATH
         });
       }
       await generatePrismaClient(

--- a/src/package-utils/log-helpers.ts
+++ b/src/package-utils/log-helpers.ts
@@ -23,8 +23,8 @@ export const PREDEFINED_LOG_MESSAGES = {
   },
   installPrismaCLI: {
     action: "Installing Prisma CLI...",
-    yes: `Successfully installed "Prisma CLI.`,
-    no: `Failed to install Prisma CLI.`,
+    success: `Successfully installed "Prisma CLI.`,
+    error: `Failed to install Prisma CLI.`,
   },
   checkIfPrismaSchemaExists: {
     yes: "Prisma schema file exists.",

--- a/src/package-utils/log-helpers.ts
+++ b/src/package-utils/log-helpers.ts
@@ -23,7 +23,7 @@ export const PREDEFINED_LOG_MESSAGES = {
   },
   installPrismaCLI: {
     action: "Installing Prisma CLI...",
-    success: `Successfully installed "Prisma CLI.`,
+    success: `Successfully installed Prisma CLI.`,
     error: `Failed to install Prisma CLI.`,
   },
   checkIfPrismaSchemaExists: {

--- a/src/package-utils/setup-helpers.ts
+++ b/src/package-utils/setup-helpers.ts
@@ -7,7 +7,6 @@ import {
 } from "./log-helpers";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
 import { join } from "pathe";
-import { addDependency, addDevDependency } from "nypm";
 
 export type DatabaseProviderType =
   | "sqlite"
@@ -23,33 +22,6 @@ export type PrismaInitOptions = {
   provider: DatabaseProviderType;
   rootDir: string;
 };
-
-export async function isPrismaCLIInstalled(
-  directory: string,
-): Promise<boolean> {
-  try {
-    await execa("npx", ["prisma", "version"], { cwd: directory });
-    logSuccess(PREDEFINED_LOG_MESSAGES.isPrismaCLIinstalled.yes);
-    return true;
-  } catch (error) {
-    logError(PREDEFINED_LOG_MESSAGES.isPrismaCLIinstalled.no);
-    // log(error);
-    return false;
-  }
-}
-
-export async function installPrismaCLI(directory: string) {
-  try {
-    await addDevDependency("prisma", {
-      cwd: directory,
-    });
-
-    logSuccess(PREDEFINED_LOG_MESSAGES.installPrismaCLI.yes);
-  } catch (err) {
-    logError(PREDEFINED_LOG_MESSAGES.installPrismaCLI.no);
-    log(err);
-  }
-}
 
 export function checkIfPrismaSchemaExists(paths: string[]) {
   const exists = paths.reduce((prev, current) => {
@@ -212,27 +184,6 @@ export async function formatSchema(directory: string, schemaPath: string[]) {
     });
   } catch {
     logError(PREDEFINED_LOG_MESSAGES.formatSchema.error);
-  }
-}
-
-export async function installPrismaClient(
-  directory: string,
-  installPrismaClient: boolean = true,
-) {
-  log(PREDEFINED_LOG_MESSAGES.generatePrismaClient.action);
-
-  if (installPrismaClient) {
-    try {
-      await addDependency("@prisma/client", {
-        cwd: directory,
-      });
-    } catch (error) {
-      logError(
-        PREDEFINED_LOG_MESSAGES.generatePrismaClient
-          .prismaClientInstallationError,
-      );
-      // log(error);
-    }
   }
 }
 


### PR DESCRIPTION
- As the title already says, this commits makes use of the `ensureDependencyInstalled` function provided by nypm.
- Also, it fixes a small typo in a log message 😄 