### PR TITLE
nuxt add-module convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ With this module, you can easily integrate Prisma ORM in your Nuxt app.
    ```bash
    npm install @prisma/nuxt
    ```
+   or run this to automatically inject `@prisma/nuxt` and skip step #2
+   ```bash
+   npx nuxi module add @prisma/nuxt 
+   ```
 
 2. Add `@prisma/nuxt` to the `modules` section of `nuxt.config.ts`
 


### PR DESCRIPTION
adds a convention-based installation method for the @prisma/nuxt module, triggering Nuxt's magic automatically. With this change, users can now quickly add the Prisma module by using npx nuxi module add @prisma/nuxt, eliminating the need for manual installation steps.